### PR TITLE
Fixed memory leak of TMMDBReader._database field

### DIFF
--- a/Source/uMMDBReader.pas
+++ b/Source/uMMDBReader.pas
@@ -1293,6 +1293,7 @@ begin
     FMetadata.Free;
   FMetaOwnerObjects.Free;
   FFindOwnerObjects.Free;
+  _database.Free;
   inherited;
 end;
 


### PR DESCRIPTION
Hi. I've found memory leak of value of TMMDBArrayBuffer type with my FastMM debugger.
Memory leak is located in uMMDBReader.pas. _database field is created in TMMDBReader.Create but not destroyed in TMMDBReader.Destroy.
I've fixed it, you can accept my pull request if you like.

Thank you for your useful library!